### PR TITLE
fix auto token refresh code when making requests

### DIFF
--- a/lib/http_client.rb
+++ b/lib/http_client.rb
@@ -60,8 +60,9 @@ module Auth
 
       if @authenticated_client.respond_to? method_name
         response = @authenticated_client.send method_name, *args, &block
-        if response.body.is_a?(::Hash) &&
-             response.body[:error] == 'Auth::Errors::TokenExpired'
+        if response.status == 401
+          # a 401 here is assumed to be due to an expired token
+          # otherwise, refreshing the token and calling again should make no difference to the ultimate response
           refresh
           response = @authenticated_client.send method_name, *args, &block
         end

--- a/spec/stubs/oauth2_stub.rb
+++ b/spec/stubs/oauth2_stub.rb
@@ -36,6 +36,7 @@ module OAuth2Stub
     private
 
     def get_response(url)
+      return expired_decoded_json_response if url.include? 'expired-decoded-json'
       return expired_response if url.include? 'expired'
       return html_response if url.include? 'html'
       return no_network if url.include? 'network_error'
@@ -55,6 +56,13 @@ module OAuth2Stub
     end
 
     def expired_response
+      OAuth2::Response.new Faraday::Response.new status: 401,
+                                                 reason_phrase: 'Unauthorized',
+                                                 response_headers: {},
+                                                 body: '{"error": "Auth::Errors::TokenExpired"}'
+    end
+
+    def expired_decoded_json_response
       OAuth2::Response.new Faraday::Response.new status: 401,
                                                  reason_phrase: 'Unauthorized',
                                                  response_headers: {},

--- a/spec/unit/http_client_spec.rb
+++ b/spec/unit/http_client_spec.rb
@@ -73,12 +73,22 @@ describe Auth::HttpClient do
                            OAuth2Stub::Client
     end
 
-    it 'calling get results in a token refresh request' do
+    it 'calling get results in a token refresh request when body available as string' do
       client.refresh
 
       allow(client).to receive :refresh
 
       expect(client.get('/get/expired')).to be_instance_of OAuth2::Response
+
+      expect(client).to have_received :refresh
+    end
+
+    it 'calling get results in a token refresh request when body available as hash of decoded JSON' do
+      client.refresh
+
+      allow(client).to receive :refresh
+
+      expect(client.get('/get/expired-decoded-json')).to be_instance_of OAuth2::Response
 
       expect(client).to have_received :refresh
     end


### PR DESCRIPTION
The code to auto-refresh tokens makes the assumption that `response.body` is available as a hash, but in the default case it is a string, and it will be hash only when, for example, Faraday is using its JSON middleware to transparently decode JSON responses.

This change ensures that a token gets refreshed if needed regardless of how Faraday would reasonably expose a response body.